### PR TITLE
Pass credentials to the Elk constructor.

### DIFF
--- a/elkm1.py
+++ b/elkm1.py
@@ -298,7 +298,12 @@ def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     #bound_event_callback = partial(_callback_from_pyelk, hass, config)
 
-    elk = elkm1.Elk({'url': elk_config[CONF_HOST]}, loop=hass.loop)
+    elk_obj_config = {'url': elk_config[CONF_HOST]}
+    if CONF_USERNAME in elk_config and CONF_PASSWORD in elk_config:
+        elk_obj_config['userid'] = elk_config[CONF_USERNAME]
+        elk_obj_config['password'] = elk_config[CONF_PASSWORD]
+
+    elk = elkm1.Elk(elk_obj_config, loop=hass.loop)
 
     hass.data['elkm1'] = {
         'connection' : elk,


### PR DESCRIPTION
This is necessary for people using the `elks://` scheme. Without the change, the code crashes because the `Elk._connected` method does not have a `userid` (nor a `password`) to use.

This commit introduces a computed configuration variable named `secure` and referred as `CONF_SECURE`. It exists only on the cleaned up configuration object ("cleaned" by opposition to "raw") and is there to avoid having to check the configuration protocol more than once. 

I thought about using a naming convention that would distinguish it from those settings that are directly accessible to the user. For instance, `_CONF_SECURE = "_secure"` but I did not know if there already were any settings that are also computed during the verification of the configuration and its conversion to a clean object. If there are other computed configuration variables, then the naming convention should be used for all of them. I did not have time to inspect the code thoroughly to identify them, so I dropped that idea.